### PR TITLE
[OT287-40] - Add conection of Navbar with routes

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,17 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types';
-import AppBar from '@mui/material/AppBar';
-import Toolbar from '@mui/material/Toolbar';
-import Container from '@mui/material/Container';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
+import {
+  Button, Box, Container, Toolbar, AppBar,
+} from '@mui/material'
 import BrandLogo from './BrandLogo';
 import BurgerMenu from './Navbar/BurgerMenu';
 import Navbar from './Navbar/Navbar';
 
-const Header = ({
-  logo, menu, handleOpenMenu, handleCloseMenu, anchorNav,
-}) => {
+const Header = (props) => {
+  const {
+    logo, menu, handleOpenMenu, handleCloseMenu, anchorNav, navigate, handleActiveButton,
+    activeButton, buttonsAction,
+  } = props
   return (
     <AppBar position="static" sx={{ backgroundColor: 'white' }}>
       <Container maxWidth="xl">
@@ -25,8 +25,12 @@ const Header = ({
           />
           <BrandLogo logo={logo} breakpointDisplay="xs" breakpointHidden="md" />
           <Navbar
+            navigate={navigate}
             menu={menu}
             handleCloseMenu={handleCloseMenu}
+            handleActiveButton={handleActiveButton}
+            activeButton={activeButton}
+            buttonsAction={buttonsAction}
           />
           <Box>
             <Button
@@ -34,17 +38,30 @@ const Header = ({
               sx={{
                 display: { xs: 'none', md: 'inline' }, mx: 1.3, color: 'black', borderColor: 'black', fontSize: { xs: '.6rem', md: '.8rem', lg: '1rem' },
               }}
+              onClick={() => {
+                handleActiveButton(buttonsAction[0].route)
+                navigate(buttonsAction[0].route)
+              }}
             >
               Log in
             </Button>
-            <Button variant="contained" color="primary" sx={{ fontSize: { xs: '.6rem', md: '.8rem', lg: '1rem' } }}>Registrate</Button>
+            <Button
+              variant="contained"
+              color="primary"
+              sx={{ fontSize: { xs: '.6rem', md: '.8rem', lg: '1rem' } }}
+              onClick={() => {
+                handleActiveButton(buttonsAction[1].route)
+                navigate(buttonsAction[1].route)
+              }}
+            >
+              Registrate
+            </Button>
           </Box>
         </Toolbar>
       </Container>
     </AppBar>
-  );
+  )
 }
-
 Header.propTypes = {
   logo: PropTypes.string.isRequired,
   menu: PropTypes.arrayOf(PropTypes.shape({
@@ -53,8 +70,16 @@ Header.propTypes = {
     route: PropTypes.string,
   })).isRequired,
   handleCloseMenu: PropTypes.func.isRequired,
+  navigate: PropTypes.func.isRequired,
   handleOpenMenu: PropTypes.func.isRequired,
   anchorNav: PropTypes.instanceOf(Element),
+  handleActiveButton: PropTypes.func.isRequired,
+  activeButton: PropTypes.string.isRequired,
+  buttonsAction: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    text: PropTypes.string,
+    route: PropTypes.string,
+  })).isRequired,
 }
 
 Header.defaultProps = {

--- a/src/components/Header/HeaderContainer.jsx
+++ b/src/components/Header/HeaderContainer.jsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom';
 import Header from './Header'
 
 const data = {
@@ -6,45 +7,72 @@ const data = {
   menu: [
     {
       id: 1,
-      route: '/home',
+      route: '/',
       text: 'Inicio',
     },
     {
       id: 2,
-      route: '/aboutUs',
+      route: '/sobre-nosotros',
       text: 'Nosotros',
     },
     {
       id: 3,
-      route: '/news',
+      route: '/novedades',
       text: 'Novedades',
     },
     {
       id: 4,
-      route: '/testimonials',
+      route: '/testimonios',
       text: 'Testimonios',
     },
     {
       id: 5,
-      route: '/contacs',
+      route: '/contacto',
       text: 'Contacto',
     },
     {
       id: 6,
-      route: '/contributes',
+      route: '/contribuye',
       text: 'Contribuye',
+    },
+  ],
+  buttonsAction: [
+    {
+      id: 7,
+      route: '/login',
+      text: 'Login',
+    },
+    {
+      id: 8,
+      route: '/registrate',
+      text: 'Registrate',
     },
   ],
 }
 
 const HeaderContainer = () => {
   const [anchorNav, setAnchorNav] = React.useState(null);
+  const [activeButton, setActiveButton] = useState('/')
+
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  useEffect(() => {
+    if (location.pathname !== activeButton) {
+      setActiveButton(location.pathname)
+    }
+  }, [activeButton, location])
+
+  const handleActiveButton = (buttonName) => {
+    setActiveButton(buttonName)
+  }
 
   const handleOpenMenu = (event) => {
     setAnchorNav(event.currentTarget);
   };
 
-  const handleCloseMenu = () => {
+  const handleCloseMenu = (route) => {
+    navigate(route)
     setAnchorNav(null);
   };
 
@@ -52,9 +80,13 @@ const HeaderContainer = () => {
     <Header
       logo={data.logo}
       menu={data.menu}
+      buttonsAction={data.buttonsAction}
       anchorNav={anchorNav}
       handleOpenMenu={handleOpenMenu}
       handleCloseMenu={handleCloseMenu}
+      navigate={navigate}
+      handleActiveButton={handleActiveButton}
+      activeButton={activeButton}
     />
   )
 }

--- a/src/components/Header/Navbar/BurgerMenu.jsx
+++ b/src/components/Header/Navbar/BurgerMenu.jsx
@@ -1,15 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types';
-import Box from '@mui/material/Box';
-import IconButton from '@mui/material/IconButton';
-import Typography from '@mui/material/Typography';
-import Menu from '@mui/material/Menu';
+import {
+  Box, Typography, Menu, MenuItem, IconButton,
+} from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
-import MenuItem from '@mui/material/MenuItem';
 
-const BurgerMenu = ({
-  menu, handleOpenMenu, handleCloseMenu, anchorNav,
-}) => {
+const BurgerMenu = (props) => {
+  const {
+    menu, handleOpenMenu, handleCloseMenu, anchorNav,
+  } = props
   return (
     <Box sx={{ display: { xs: 'flex', md: 'none' }, justifyContent: 'right', mr: 4 }}>
       <IconButton
@@ -40,7 +39,7 @@ const BurgerMenu = ({
         }}
       >
         {menu.map((page) => (
-          <MenuItem key={page.id} onClick={handleCloseMenu}>
+          <MenuItem key={page.id} onClick={() => handleCloseMenu(page.route)}>
             <Typography textAlign="center">{page.text}</Typography>
           </MenuItem>
         ))}

--- a/src/components/Header/Navbar/Navbar.jsx
+++ b/src/components/Header/Navbar/Navbar.jsx
@@ -1,24 +1,29 @@
 import React from 'react'
 import PropTypes from 'prop-types';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
+import { Box, Button } from '@mui/material';
 
-const Navbar = ({ menu }) => {
-  return (
-    <Box sx={{ display: { xs: 'none', md: 'flex' }, flexGrow: 1, justifyContent: 'right' }}>
-      {menu.map((page) => (
-        <Button
-          key={page.id}
-          sx={{
-            my: 2, mx: { md: 0.5, lg: 0.8 }, display: 'block', color: 'black', fontSize: { lg: '1rem' },
-          }}
-        >
-          {page.text}
-        </Button>
-      ))}
-    </Box>
-  )
-}
+const Navbar = ({
+  menu, navigate, handleActiveButton, activeButton,
+}) => (
+  <Box sx={{ display: { xs: 'none', md: 'flex' }, flexGrow: 1, justifyContent: 'right' }}>
+    {menu.map((page) => (
+
+      <Button
+        key={page.id}
+        onClick={() => {
+          handleActiveButton(page.route)
+          navigate(page.route)
+        }}
+        sx={{
+          my: 2, mx: { md: 0.5, lg: 0.8 }, display: 'block', color: 'black', fontSize: { lg: '1rem' }, backgroundColor: activeButton === page.route ? '#ffcdd2' : null,
+        }}
+      >
+        {page.text}
+      </Button>
+
+    ))}
+  </Box>
+)
 
 Navbar.propTypes = {
   menu: PropTypes.arrayOf(PropTypes.shape({
@@ -26,6 +31,9 @@ Navbar.propTypes = {
     text: PropTypes.string,
     route: PropTypes.string,
   })).isRequired,
+  navigate: PropTypes.func.isRequired,
+  handleActiveButton: PropTypes.func.isRequired,
+  activeButton: PropTypes.string.isRequired,
 }
 
 export default Navbar


### PR DESCRIPTION
## Jira Ticket

- [OT287-40](https://alkemy-labs.atlassian.net/browse/OT287-40)

## Description
AS: Usuario
I Want: Tener acceso a todas las pagianas de la web a traves de la navbar
To: Hacer mas simple la navegación

Criterios de aceptación: Vincular las pantallas existentes con la barra de navegación del componente Header. Debe ser un array de items de navegación, con el texto y la ruta hacia la que direccionan al hacer click. También deberá mostrar un ítem de navegación con clase "active" en el caso de que la ruta actual se corresponda con el mismo


## Evidence:

Ejemplo: Al comenzar la navegación
![conexion navbar](https://user-images.githubusercontent.com/85040647/192518775-46226521-342b-4e18-8a1a-043478471851.png)


Ejemplo: Al navegar hacia 'Novedades' 
![navegacion a novedades](https://user-images.githubusercontent.com/85040647/192518812-6185a8ac-803b-4396-8e69-3d8743b683dd.png)
