### PR TITLE
[OT287-47] Back-office/news: Create list of news

### DIFF
--- a/src/components/BackOffice/BackOfficeContainer.jsx
+++ b/src/components/BackOffice/BackOfficeContainer.jsx
@@ -80,11 +80,12 @@ const drawerOptions = [
   {
     text: 'news',
     icon: <NewspaperIcon />,
+    route: '/back-office/news',
   },
   {
     text: 'activities',
     icon: <VolunteerActivismIcon />,
-    route: '/backoffice/activities',
+    route: '/back-office/activities',
   },
   {
     text: 'categories',

--- a/src/components/BackOffice/news/News.jsx
+++ b/src/components/BackOffice/news/News.jsx
@@ -7,16 +7,21 @@ import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import EditIcon from '@mui/icons-material/Edit';
 
 const Users = ({ news }) => (
-  <Box sx={{ width: '100vw', height: '100vh' }}>
-    <Typography component="h1" variant="h5" sx={{ marginY: '40px', fontWeight: 'bold' }}>Lista de Novedades</Typography>
-    <TableContainer sx={{ position: 'absolute', top: '180px', width: { lg: '85%', xs: '100%' } }} component={Paper}>
+  <Box>
+    <Typography component="h1" variant="h5" sx={{ marginY: { lg: '40px', xs: '10px' }, fontWeight: 'bold' }}>Lista de Novedades</Typography>
+    <TableContainer
+      sx={{
+        position: 'absolute', top: '180px', height: '400px', overflow: 'auto', width: { lg: '85%', xs: '100vw' },
+      }}
+      component={Paper}
+    >
       <Table>
         <TableHead>
-          <TableRow>
+          <TableRow sx={{ backgroundColor: 'rgb(240,240,240)' }}>
             <TableCell><b>Nombre</b></TableCell>
             <TableCell><b>URL Imagen</b></TableCell>
             <TableCell><b>Fecha creacion</b></TableCell>
-            <TableCell><b>Acciones</b></TableCell>
+            <TableCell align="center"><b>Acciones</b></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -26,7 +31,7 @@ const Users = ({ news }) => (
               <TableCell>{elem.name}</TableCell>
               <TableCell>{elem.image}</TableCell>
               <TableCell>{elem.createdAt}</TableCell>
-              <TableCell style={{ padding: '0', width: '60px' }}>
+              <TableCell style={{ padding: '0', width: '60px' }} align="center">
                 <>
                   <EditIcon sx={{
                     opacity: '0.5', padding: '1px', border: '1px solid red', borderRadius: '5px', backgroundColor: 'white', color: 'red', fontSize: '1.8rem', margin: '0 5px', cursor: 'pointer', '&:hover': { opacity: '1' },

--- a/src/components/BackOffice/news/News.jsx
+++ b/src/components/BackOffice/news/News.jsx
@@ -6,7 +6,7 @@ import {
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import EditIcon from '@mui/icons-material/Edit';
 
-const Users = ({ news }) => (
+const News = ({ news }) => (
   <Box>
     <Typography component="h1" variant="h5" sx={{ marginY: { lg: '40px', xs: '10px' }, fontWeight: 'bold' }}>Lista de Novedades</Typography>
     <TableContainer
@@ -59,11 +59,11 @@ const Users = ({ news }) => (
   </Box>
 
 )
-Users.propTypes = {
+News.propTypes = {
   news: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string,
     image: PropTypes.string,
     createdAt: PropTypes.string,
   })).isRequired,
 }
-export default Users
+export default News

--- a/src/components/BackOffice/news/News.jsx
+++ b/src/components/BackOffice/news/News.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  Box, Table, TableRow, TableHead, TableContainer, TableCell, TableBody, Paper, Typography,
+} from '@mui/material'
+import HighlightOffIcon from '@mui/icons-material/HighlightOff';
+import EditIcon from '@mui/icons-material/Edit';
+
+const Users = ({ news }) => (
+  <Box sx={{ width: '100vw', height: '100vh' }}>
+    <Typography component="h1" variant="h5" sx={{ marginY: '40px', fontWeight: 'bold' }}>Lista de Novedades</Typography>
+    <TableContainer sx={{ position: 'absolute', top: '180px', width: { lg: '85%', xs: '100%' } }} component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell><b>Nombre</b></TableCell>
+            <TableCell><b>URL Imagen</b></TableCell>
+            <TableCell><b>Fecha creacion</b></TableCell>
+            <TableCell><b>Acciones</b></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {news.map((elem) => (
+
+            <TableRow key={elem.id}>
+              <TableCell>{elem.name}</TableCell>
+              <TableCell>{elem.image}</TableCell>
+              <TableCell>{elem.createdAt}</TableCell>
+              <TableCell style={{ padding: '0', width: '60px' }}>
+                <>
+                  <EditIcon sx={{
+                    opacity: '0.5', padding: '1px', border: '1px solid red', borderRadius: '5px', backgroundColor: 'white', color: 'red', fontSize: '1.8rem', margin: '0 5px', cursor: 'pointer', '&:hover': { opacity: '1' },
+                  }}
+                  />
+                  <HighlightOffIcon sx={{
+                    opacity: '0.5',
+                    padding: '1px',
+                    borderRadius: '5px',
+                    backgroundColor: 'red',
+                    color: 'white',
+                    fontSize: '1.8rem',
+                    margin: '0 5px',
+                    cursor: 'pointer',
+                    '&:hover': { opacity: '1' },
+                  }}
+                  />
+                </>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  </Box>
+
+)
+Users.propTypes = {
+  news: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string,
+    image: PropTypes.string,
+    createdAt: PropTypes.string,
+  })).isRequired,
+}
+export default Users

--- a/src/components/BackOffice/news/News.jsx
+++ b/src/components/BackOffice/news/News.jsx
@@ -11,7 +11,7 @@ const Users = ({ news }) => (
     <Typography component="h1" variant="h5" sx={{ marginY: { lg: '40px', xs: '10px' }, fontWeight: 'bold' }}>Lista de Novedades</Typography>
     <TableContainer
       sx={{
-        position: 'absolute', top: '180px', height: '400px', overflow: 'auto', width: { lg: '85%', xs: '100vw' },
+        position: 'absolute', top: '180px', height: '400px', overflow: 'auto', width: { lg: '80%', xs: '100%' },
       }}
       component={Paper}
     >
@@ -29,9 +29,9 @@ const Users = ({ news }) => (
 
             <TableRow key={elem.id}>
               <TableCell>{elem.name}</TableCell>
-              <TableCell>{elem.image}</TableCell>
-              <TableCell>{elem.createdAt}</TableCell>
-              <TableCell style={{ padding: '0', width: '60px' }} align="center">
+              <TableCell sx={{ width: '30px', overflow: 'hidden', textOverflow: 'ellipsis' }}>{elem.image}</TableCell>
+              <TableCell sx={{ width: '220px', overflow: 'hidden', textOverflow: 'ellipsis' }}>{elem.createdAt}</TableCell>
+              <TableCell sx={{ padding: '0', width: '60px' }} align="center">
                 <>
                   <EditIcon sx={{
                     opacity: '0.5', padding: '1px', border: '1px solid red', borderRadius: '5px', backgroundColor: 'white', color: 'red', fontSize: '1.8rem', margin: '0 5px', cursor: 'pointer', '&:hover': { opacity: '1' },

--- a/src/components/BackOffice/news/NewsContainer.jsx
+++ b/src/components/BackOffice/news/NewsContainer.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import News from './News'
+
+const news = [
+
+  {
+    id: '1',
+    name: 'Lorem Ipsum causes Chaos',
+    image: 'https://picsum.photos/200/300',
+    createdAt: '2022-09-26 23:24:39',
+  },
+  {
+    id: '2',
+    name: 'Lorem Ipsum takes over',
+    image: 'https://picsum.photos/300/300',
+    createdAt: '2022-09-25 23:24:39',
+  },
+  {
+    id: '3',
+    name: 'Lorem Ipsum strikes again',
+    image: 'https://picsum.photos/200/300',
+    createdAt: '2022-09-21 23:24:39',
+  },
+  {
+    id: '4',
+    name: 'Lorem Ipsum the revenge',
+    image: 'https://picsum.photos/200/300',
+    createdAt: '2022-09-19 23:24:39',
+  },
+  {
+    id: '5',
+    name: 'Lorem Ipsum vs asdasdasd',
+    image: 'https://picsum.photos/200/300',
+    createdAt: '2022-09-10 23:24:39',
+  },
+  {
+    id: '6',
+    name: 'Lorem Ipsum goes aaaaaaaaaaaaaaaa',
+    image: 'https://picsum.photos/200/300',
+    createdAt: '2022-08-26 23:24:39',
+  },
+
+]
+
+const NewsContainer = () => (
+  <div>
+    <News news={news} />
+  </div>
+)
+
+export default NewsContainer

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -8,9 +8,10 @@ import NewsContainer from '../components/News/NewsContainer'
 import NewsByIdContainer from '../components/News/NewByIdContainer'
 import MyProfileContainer from '../components/MyProfile/MyProfileContainer'
 import MainLayout from '../pages/MainLayout'
-import BackofficeUsers from '../components/BackOffice/users/UsersContainer'
 import ContactScreen from '../components/Contact/ContactScreen'
 import EditOrganizationContainer from '../components/Forms/OrganizationForm/EditOrganizationContainer'
+import BackofficeUsers from '../components/BackOffice/users/UsersContainer'
+import BackofficeNews from '../components/BackOffice/news/NewsContainer'
 
 const Router = () => (
   <Routes>
@@ -19,13 +20,15 @@ const Router = () => (
       <Route path="/login" element={<LoginFormContainer />} />
       <Route path="/registrate" element={<RegisterFormContainer />} />
       <Route path="/mi-perfil" element={<MyProfileContainer />} />
-      <Route path="/back-office" element={<BackOfficeContainer />}>
-        <Route path="organization-edit" element={<EditOrganizationContainer />} />
-        <Route path="users" element={<BackofficeUsers />} />
-      </Route>
       <Route path="/novedades" element={<NewsContainer />} />
       <Route path="/novedades/:id" element={<NewsByIdContainer />} />
       <Route path="/contacto" element={<ContactScreen />} />
+      {/* Back-Office Routes for Admin access only */}
+      <Route path="/back-office" element={<BackOfficeContainer />}>
+        <Route path="organization-edit" element={<EditOrganizationContainer />} />
+        <Route path="users" element={<BackofficeUsers />} />
+        <Route path="news" element={<BackofficeNews />} />
+      </Route>
     </Route>
   </Routes>
 )


### PR DESCRIPTION
## Jira Ticket

- [OT287-47](https://alkemy-labs.atlassian.net/browse/OT287-47)

## Description
AS: Usuario administrador
I Want: Ver el listado de Novedades 
To: Tener conocimiento de las Novedades de la web

Criterios de aceptación: Al ingresar a la ruta /backoffice/news, mostrará el listado de Novedades para el usuario administrador en una tabla. Obtendrá los datos del endpoint de listado de Novedades, en el caso de que aún no esté listo, los obtendrá desde un array que representarán los datos. Esta tabla mostará los campos name, image, createdAt, y las acciones para eliminar y editar una novedad.

## Evidence:
News Table
![image](https://user-images.githubusercontent.com/547180/193124454-e34be4fc-37b0-428a-9d18-fcdbe4c742d8.png)

Mobile view
![image](https://user-images.githubusercontent.com/547180/193121633-c253c533-22a0-4d1a-a8ec-55fc998b3478.png)


