### PR TITLE
[OT287] Front: Design layout fixes proposition

### DIFF
--- a/src/components/BackOffice/BackOffice.jsx
+++ b/src/components/BackOffice/BackOffice.jsx
@@ -19,7 +19,7 @@ const BackOffice = ({
   location,
 }) => (
   <>
-    <Box sx={{ display: 'flex', minHeight: '100vh' }} position="relative">
+    <Box sx={{ display: 'flex', minHeight: '100vh', top: '-120px' }} position="relative">
       <DrawerMenu
         options={options}
         mobileOpen={mobileOpen}

--- a/src/components/BackOffice/BackOfficeContainer.jsx
+++ b/src/components/BackOffice/BackOfficeContainer.jsx
@@ -98,6 +98,7 @@ const drawerOptions = [
   {
     text: 'organizations',
     icon: <AccountTreeIcon />,
+    route: '/back-office/organizations',
   },
   {
     text: 'slides',
@@ -158,7 +159,7 @@ const cardFields = {
 
 const nestedRoutes = {
   organizations: {
-    edit: 'organization-edit',
+    edit: 'organizations/:id/edit',
   },
 }
 

--- a/src/components/BackOffice/DrawerMenu.jsx
+++ b/src/components/BackOffice/DrawerMenu.jsx
@@ -14,7 +14,7 @@ const DrawerMenu = ({
   <>
     <CssBaseline />
     <Box sx={{
-      backgroundColor: 'white', position: 'absolute', zIndex: 1500, top: 0, left: 0, width: 100, height: 50, display: { sm: 'none' },
+      backgroundColor: 'rgb(240,240,240)', position: 'fixed', zIndex: 1500, top: 0, left: 0, width: 100, height: 50, display: { sm: 'none' },
     }}
     >
       <IconButton

--- a/src/components/Forms/OrganizationForm/EditOrganizationContainer.jsx
+++ b/src/components/Forms/OrganizationForm/EditOrganizationContainer.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom'
+import React, { useCallback, useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import EditOrganizationForm from './EditOrganizationForm'
 import validationSchema from '../../../schemas/organization'
 import httpService from '../../../services/httpService';
@@ -7,11 +7,27 @@ import httpService from '../../../services/httpService';
 const EditOrganizationContainer = () => {
   const [errorStatus, setErrorStatus] = useState(null)
   const [errorMessage, setErrorMessage] = useState(null)
+  const [dataOrg, setDataOrg] = useState({})
+
   const navigate = useNavigate()
+  const { id } = useParams()
+
+  const getOrganizationData = useCallback(async () => {
+    try {
+      const data = await httpService('get', `organizations/${id}/public`)
+      if (data.code === 200) {
+        setDataOrg(data.body)
+      } else {
+        setErrorStatus(data.code)
+      }
+    } catch (error) {
+      setErrorStatus(error.response)
+    }
+  }, [id])
 
   const onSubmitForm = async (values) => {
     try {
-      await httpService('put', 'organizations/1', values)
+      await httpService('put', `organizations/${id}/edit`, values)
       navigate('/back-office')
     } catch (error) {
       setErrorStatus(error.response.status)
@@ -20,9 +36,21 @@ const EditOrganizationContainer = () => {
   }
 
   const initialValues = {
-    name: '',
-    image: null,
+    name: dataOrg.name,
+    image: dataOrg.image,
+    address: dataOrg.address,
+    phone: dataOrg.phone,
+    email: dataOrg.email,
+    fbUrl: dataOrg.fbUrl,
+    igUrl: dataOrg.igUrl,
+    ldUrl: dataOrg.ldUrl,
+    welcomeText: dataOrg.welcomeText,
+    aboutUsText: dataOrg.aboutUsText,
   }
+
+  useEffect(() => {
+    getOrganizationData()
+  }, [getOrganizationData])
 
   return (
     <EditOrganizationForm

--- a/src/components/Forms/OrganizationForm/EditOrganizationForm.jsx
+++ b/src/components/Forms/OrganizationForm/EditOrganizationForm.jsx
@@ -9,10 +9,9 @@ import FormInputField from '../../Layout/FormInputField'
 import FormInputImage from '../../Layout/FormInputImage'
 
 const EditOrganizationForm = ({
-  initialValues, onSubmitForm, validationSchema, error, errorMessage,
+  onSubmitForm, initialValues, validationSchema, error, errorMessage,
 }) => {
   const navigate = useNavigate()
-
   const handleClose = () => {
     navigate('/back-office')
   }
@@ -25,6 +24,7 @@ const EditOrganizationForm = ({
         initialValues={initialValues}
         validationSchema={validationSchema}
         onSubmit={(values) => onSubmitForm(values)}
+        enableReinitialize
       >
         {(formProps) => (
           <Box sx={{ mx: 2 }}>
@@ -34,7 +34,26 @@ const EditOrganizationForm = ({
                   <FormInputField label="Nombre" name="name" type="text" variant="outlined" sx={{ h: 10 }} />
                 </Grid>
                 <Grid item xs={12}>
-                  <FormInputImage label="Upload" name="image" type="file" formProps={formProps} />
+                  <FormInputField label="Direccion" name="address" type="text" variant="outlined" sx={{ h: 10 }} />
+                </Grid>
+                <Grid item xs={12}>
+                  <FormInputField label="Telefono" name="phone" type="text" variant="outlined" sx={{ h: 10 }} />
+                </Grid>
+                <Grid item xs={12}>
+                  <FormInputField label="email" name="email" type="text" variant="outlined" sx={{ h: 10 }} />
+                </Grid>
+                <Grid item xs={12}>
+                  <FormInputField label="URL Facebook" name="fbUrl" type="text" variant="outlined" sx={{ h: 10 }} />
+                </Grid>
+                <Grid item xs={12}>
+                  <FormInputField label="URL Instagram" name="igUrl" type="text" variant="outlined" sx={{ h: 10 }} />
+                </Grid>
+                <Grid item xs={12}>
+                  <FormInputField label="URL Linkedin" name="ldUrl" type="text" variant="outlined" sx={{ h: 10 }} />
+                </Grid>
+                <Grid item xs={12}>
+                  {/* Cargar imagen todavia no hace nada, no esta asociada la funcionalidad */}
+                  <FormInputImage label="Cargar Imagen" name="image" type="file" formProps={formProps} />
                 </Grid>
               </Grid>
               <DialogActions>
@@ -63,10 +82,14 @@ const EditOrganizationForm = ({
 
 EditOrganizationForm.propTypes = {
   initialValues: PropTypes.shape({
-    firstName: PropTypes.string,
-    lastName: PropTypes.string,
+    name: PropTypes.string,
+    image: PropTypes.string,
+    address: PropTypes.string,
+    phone: PropTypes.string,
     email: PropTypes.string,
-    password: PropTypes.string,
+    fbUrl: PropTypes.string,
+    igUrl: PropTypes.string,
+    ldUrl: PropTypes.string,
   }).isRequired,
   onSubmitForm: PropTypes.func.isRequired,
   validationSchema: PropTypes.oneOfType([PropTypes.object]).isRequired,

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -13,7 +13,12 @@ const Header = (props) => {
     activeButton, buttonsAction,
   } = props
   return (
-    <AppBar position="absolute" sx={{ backgroundColor: 'white', zIndex: 1300 }}>
+    <AppBar
+      position="fixed"
+      sx={{
+        backgroundColor: 'rgb(240,240,240)', zIndex: 1300,
+      }}
+    >
       <Container maxWidth="xl">
         <Toolbar disableGutters sx={{ display: 'flex', justifyContent: 'space-between' }}>
           <BrandLogo logo={logo} breakpointDisplay="md" breakpointHidden="xs" />

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -12,7 +12,7 @@ const Home = ({ news, slider }) => (
     <Slider items={slider} />
     <h2>Ultimas novedades</h2>
     <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(2, auto)', padding: { xs: '15px' } }}>
-      {news?.length > 1 ? news.map((elem) => (
+      {news.length > 1 ? news.map((elem) => (
         <Grid key={elem.id} container height="230px">
           <Grid sx={{ position: { lg: 'relative' }, left: { lg: '120px' } }} item xs={6} lg={4}>
             <Box sx={{ backgroundColor: '#448fdf', width: { lg: '650px', xs: '150px' } }} border={2} borderColor="#264f7c" borderRadius="20px">

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -12,7 +12,7 @@ const Home = ({ news, slider }) => (
     <Slider items={slider} />
     <h2>Ultimas novedades</h2>
     <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(2, auto)', padding: { xs: '15px' } }}>
-      {news.length > 1 ? news.map((elem) => (
+      {news?.length > 1 ? news.map((elem) => (
         <Grid key={elem.id} container height="230px">
           <Grid sx={{ position: { lg: 'relative' }, left: { lg: '120px' } }} item xs={6} lg={4}>
             <Box sx={{ backgroundColor: '#448fdf', width: { lg: '650px', xs: '150px' } }} border={2} borderColor="#264f7c" borderRadius="20px">

--- a/src/components/Home/HomeContainer.jsx
+++ b/src/components/Home/HomeContainer.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
-import Home from './Home'
 import httpService from '../../services/httpService'
+import Home from './Home'
 
 const sliderImg = [
   {
@@ -24,13 +24,11 @@ const HomeContainer = () => {
   const [data, setData] = useState([])
   useEffect(() => {
     httpService('GET', '/news').then((response) => {
-      setData(response.body.slice(response.body.length - 4))
+      setData(response.body.slice(response.body.length - 4) || [])
     })
   }, [])
   return (
-    <>
-      <Home news={data} slider={sliderImg} />
-    </>
+    <Home news={data} slider={sliderImg} />
   )
 }
 export default HomeContainer

--- a/src/components/Home/HomeContainer.jsx
+++ b/src/components/Home/HomeContainer.jsx
@@ -24,7 +24,11 @@ const HomeContainer = () => {
   const [data, setData] = useState([])
   useEffect(() => {
     httpService('GET', '/news').then((response) => {
-      setData(response.body.slice(response.body.length - 4) || [])
+      if (response.body && response.body.length > 4) {
+        setData(response.body.slice(response.body.length - 4))
+      } else {
+        setData(response.body)
+      }
     })
   }, [])
   return (

--- a/src/components/News/NewsCards.jsx
+++ b/src/components/News/NewsCards.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
+import { Grid, Container, Box } from '@mui/material'
 import MediaCard from './MediaCard'
-import { Container } from '@mui/system'
-import { Grid, Box } from '@mui/material'
 
 
 const NewsCards = ({data, error, errorMessage}) => {

--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -16,11 +16,9 @@ function Footer({ logo, menu, contact }) {
       disableGutters
       sx={{
         width: '100%',
-        backgroundColor: 'rgb(200,200,200)',
-        position: 'absolute',
-        margin: 0,
+        backgroundColor: 'rgb(240,240,240)',
         padding: 0,
-        height: '30%',
+        height: '240px',
         justifyContent: 'center',
       }}
     >
@@ -33,7 +31,7 @@ function Footer({ logo, menu, contact }) {
             left: { lg: '42%', xs: '27%' },
             bottom: '30px',
             height: '50px',
-            backgroundColor: 'rgb(200,200,200)',
+            backgroundColor: 'rgb(240,240,240)',
           }}
           component="img"
           src={logo}

--- a/src/pages/MainLayout/index.jsx
+++ b/src/pages/MainLayout/index.jsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import { Box } from '@mui/material'
 import FooterContainer from '../../components/footer/FooterContainer'
 import HeaderContainer from '../../components/Header/HeaderContainer';
 
 const MainLayout = () => (
-  <>
+  <Box height="100vh">
     <HeaderContainer />
-    <Outlet />
+    <Box sx={{ margin: '120px 0 20px 0' }}>
+      <Outlet />
+    </Box>
     <FooterContainer />
-  </>
+  </Box>
 )
 
 export default MainLayout;

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -27,7 +27,8 @@ const Router = () => (
       <Route path="/contacto" element={<ContactScreen />} />
       {/* Back-Office Routes for Admin access only */}
       <Route path="/back-office" element={<BackOfficeContainer />}>
-        <Route path="organization-edit" element={<EditOrganizationContainer />} />
+        <Route path="organizations" element={<BackofficeNews />} />
+        <Route path="organizations/:id/edit" element={<EditOrganizationContainer />} />
         <Route path="users" element={<BackofficeUsers />} />
         <Route path="news" element={<BackofficeNews />} />
         <Route path="news/:id" element={<BackofficeNews />} />

--- a/src/services/httpService.js
+++ b/src/services/httpService.js
@@ -2,12 +2,12 @@ import axios from 'axios'
 
 const httpService = async (method, url, body) => {
   try {
-    const { token } = JSON.parse(localStorage.getItem('user'));
+    const userIsLogged = JSON.parse(localStorage.getItem('user'));
     let headers = {}
-    if (token) {
+    if (userIsLogged) {
       headers = {
         'Content-type': 'application/json; charset=UTF-8',
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${userIsLogged.token}`,
       }
     } else {
       headers = {

--- a/src/services/httpService.js
+++ b/src/services/httpService.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 const httpService = async (method, url, body) => {
   try {
-    const token = JSON.parse(localStorage.getItem('token'));
+    const { token } = JSON.parse(localStorage.getItem('user'));
     let headers = {}
     if (token) {
       headers = {


### PR DESCRIPTION
## Description
Edits no muy complejos a los siquientes items para:
- Evitar romper el layout independiente de la cantidad de informacion cargada
- Que el header siempre este visible
- Que ambos footer y header tengan un diseño mas acorde.

## Evidence:

https://user-images.githubusercontent.com/547180/193467097-a5dcb1dc-fd37-4e60-bd70-bc4d12a95414.mp4


https://user-images.githubusercontent.com/547180/193467083-b5fa87aa-7274-46b6-86f6-491a8e65fa31.mp4


https://user-images.githubusercontent.com/547180/193467087-7b8ba6a6-8a14-4d45-82fd-54f7db83718e.mp4


