### PR TITLE
[Fix] Back office margins

### DIFF
--- a/src/components/BackOffice/BackOffice.jsx
+++ b/src/components/BackOffice/BackOffice.jsx
@@ -27,13 +27,13 @@ const BackOffice = ({
         handleFilterList={handleFilterList}
         handleDrawerToggle={handleDrawerToggle}
       />
-      { location === '/back-office'
-        ? <Items array={data} cardFields={cardFields} nestedRoutes={nestedRoutes} />
-        : (
-          <Box maxWidth="md" sx={{ mt: 10, ml: { md: 4 }, width: '100%' }}>
+      <Box maxWidth="md" sx={{ mt: 10, ml: { md: 4 }, width: '100%' }}>
+        { location === '/back-office'
+          ? <Items array={data} cardFields={cardFields} nestedRoutes={nestedRoutes} />
+          : (
             <Outlet />
-          </Box>
-        )}
+          )}
+      </Box>
     </Box>
     <AddButton handleAction={handleAction} />
   </>

--- a/src/components/BackOffice/Items.jsx
+++ b/src/components/BackOffice/Items.jsx
@@ -5,7 +5,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import ItemCard from './ItemCard'
 
 const Items = ({ array, cardFields, nestedRoutes }) => (
-  <Box sx={{ m: '1rem', mt: '6rem', width: '100%' }}>
+  <Box sx={{ my: '1rem', width: '100%' }}>
     <Grid container rowSpacing={2} columnSpacing={{ xs: 1, sm: 2, md: 3 }}>
       { array && array.map((el) => (
         <Grid xs={12} sm={6} md={4} key={el.id}>


### PR DESCRIPTION
Problem: 

- The `<Items />` component has a margin-top.
- The back office applies a margin-top to the element that is rendered by the `<outlet />` (this did not affect `<Items />` at the moment).
- Categories use `<Items />` to display their items and are rendered by the outlet, as a result, a margin-top **is applied twice**.
![image](https://user-images.githubusercontent.com/74195715/193698073-4a05ea93-9542-4f32-bdd7-980a582d1678.png)

Solution:
1. Remove the margin from the `<Items />` component.
2. Make the `<BackOffice />` component apply the margins correctly, whether it comes from the outlet or not.

![image](https://user-images.githubusercontent.com/74195715/193698957-95f49033-6927-4f91-b1b2-2ee938992ca6.png)

