### PR TITLE
[OT287-122] Add update user after edit profile

### DIFF
--- a/src/app/slices/auth/authSlice.js
+++ b/src/app/slices/auth/authSlice.js
@@ -16,9 +16,13 @@ export const authSlice = createSlice({
       state.userData = null
       localStorage.removeItem('user')
     },
+    updateUserData: (state, action) => {
+      state.userData = action.payload
+      localStorage.setItem('user', JSON.stringify(state.userData))
+    },
   },
 })
 
-export const { setUserData, destroyUserData } = authSlice.actions
+export const { setUserData, destroyUserData, updateUserData } = authSlice.actions
 
 export default authSlice.reducer

--- a/src/components/Forms/EditUserProfile/EditUserProfileContainer.jsx
+++ b/src/components/Forms/EditUserProfile/EditUserProfileContainer.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react'
+import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
+import { updateUserData } from '../../../app/slices/auth/authSlice'
 import httpService from '../../../services/httpService'
 import Loader from '../../Loader/Loader'
 import EditUserProfile from './EditUserProfile'
@@ -10,6 +12,7 @@ const EditUserProfileContainer = () => {
   const [errorMessage, setErrorMessage] = useState(null)
   const [loading, setLoading] = useState(false)
 
+  const dispatch = useDispatch()
   const navigate = useNavigate()
 
   const getUser = async () => {
@@ -39,11 +42,18 @@ const EditUserProfileContainer = () => {
   const onSubmitForm = async (values) => {
     const { id } = values
     try {
-      await httpService('put', `users/${id}`, {
+      const res = await httpService('put', `users/${id}`, {
         firstName: values.firstName,
         lastName: values.lastName,
         email: values.email,
       })
+      const userData = {
+        id: res.body.updateUser.id,
+        userName: `${res.body.updateUser.firstName} ${res.body.updateUser.lastName}`,
+        image: res.body.updateUser.image,
+        token: res.body.token,
+      }
+      dispatch(updateUserData(userData))
       setEditSucces(true)
       editSuccesNavigation()
     } catch (error) {


### PR DESCRIPTION
## Jira Ticket

- [OT287-122](https://alkemy-labs.atlassian.net/browse/OT287-122?atlOrigin=eyJpIjoiOTExODllOTQ5NjBjNGQzN2FjYTU2MGY2YzQ1YzQzZmIiLCJwIjoiaiJ9)

## Description
COMO usuario
QUIERO actualizar información de la organización
PARA mantener la información actualizada.

Criterios de aceptación:
PUT /organization/:id - Deberá validar que la organización existe y actualizarla, caso contrario devolver un error. También se deberá re-setear el token JWT en caso de que un usuario (administrador o no) actualizé su propio perfil.

- **Implementé la funcionalidad de re-setear/actualizar el token en el front una vez que se edite el perfil**

## Evidence:

![efitprofev](https://user-images.githubusercontent.com/85371377/195375480-4a4853c2-7b72-4156-93ee-13c9e404f26c.gif)

