### PR TITLE
[OT287-Fix-#025] Container: Adding minHeight to container for footer location

### DIFF
--- a/src/pages/MainLayout/index.jsx
+++ b/src/pages/MainLayout/index.jsx
@@ -5,9 +5,9 @@ import FooterContainer from '../../components/footer/FooterContainer'
 import HeaderContainer from '../../components/Header/HeaderContainer';
 
 const MainLayout = () => (
-  <Box height="100vh">
+  <Box>
     <HeaderContainer />
-    <Box sx={{ margin: '120px 0 20px 0' }}>
+    <Box sx={{ minHeight: 'calc(100vh - 380px)', margin: '120px 0 20px 0' }}>
       <Outlet />
     </Box>
     <FooterContainer />


### PR DESCRIPTION
Adding minHeight to container for footer proper location

Wrong behavior:
![image](https://user-images.githubusercontent.com/547180/195433238-55789914-3b06-4687-a641-64c23f9e6de8.png)


Correct behavior examples:
![image](https://user-images.githubusercontent.com/547180/195432652-9dcb5ffb-55cd-4ca6-a29f-74c2d9a123bb.png)

![image](https://user-images.githubusercontent.com/547180/195432709-d3ed4b04-f3fc-4bc5-98d2-d780c85d2b0a.png)

![image](https://user-images.githubusercontent.com/547180/195432811-886bc35c-1359-408d-8595-a215dfb7f64f.png)



