### PR TITLE
[OT287-Fix-#013] News Table layout Overhaul to add additional content

### DIFF
--- a/src/components/BackOffice/news/News.jsx
+++ b/src/components/BackOffice/news/News.jsx
@@ -41,9 +41,9 @@ const News = (
           }}
           component={Paper}
         >
-          <Table>
+          <Table stickyHeader>
             <TableHead>
-              <TableRow sx={{ backgroundColor: 'rgb(240,240,240)' }} stickyHeader>
+              <TableRow>
                 <TableCell><b>Nombre</b></TableCell>
                 <TableCell align="center"><b>Imagen</b></TableCell>
                 <TableCell><b>Contenido</b></TableCell>
@@ -99,10 +99,10 @@ const News = (
                         <EditIcon sx={{
                           opacity: '0.5',
                           padding: '1px',
-                          border: '1px solid red',
+                          border: '1px solid #DB5752',
                           borderRadius: '5px',
                           backgroundColor: 'white',
-                          color: 'red',
+                          color: '#DB5752',
                           fontSize: '1.8rem',
                           margin: '0 5px',
                           cursor: 'pointer',
@@ -116,7 +116,7 @@ const News = (
                           opacity: '0.5',
                           padding: '1px',
                           borderRadius: '5px',
-                          backgroundColor: 'red',
+                          backgroundColor: '#DB5752',
                           color: 'white',
                           fontSize: '1.8rem',
                           margin: '0 5px',

--- a/src/components/BackOffice/news/News.jsx
+++ b/src/components/BackOffice/news/News.jsx
@@ -9,6 +9,10 @@ import HighlightOffIcon from '@mui/icons-material/HighlightOff'
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteModal from '../../Layout/DeleteModal'
 
+function isImage(url) {
+  return /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(url);
+}
+
 const News = (
   props,
 ) => {
@@ -39,9 +43,10 @@ const News = (
         >
           <Table>
             <TableHead>
-              <TableRow sx={{ backgroundColor: 'rgb(240,240,240)' }}>
+              <TableRow sx={{ backgroundColor: 'rgb(240,240,240)' }} stickyHeader>
                 <TableCell><b>Nombre</b></TableCell>
-                <TableCell><b>URL Imagen</b></TableCell>
+                <TableCell align="center"><b>Imagen</b></TableCell>
+                <TableCell><b>Contenido</b></TableCell>
                 <TableCell><b>Fecha creacion</b></TableCell>
                 <TableCell align="center"><b>Acciones</b></TableCell>
               </TableRow>
@@ -50,34 +55,45 @@ const News = (
 
               {news && news.map((elem) => (
 
-                <TableRow key={elem.id}>
+                <TableRow key={elem.id} height="60px">
                   <TableCell
-                    sx={{ width: '25%', overflow: 'hidden', textOverflow: 'ellipsis' }}
+                    sx={{ width: '15%', overflow: 'hidden', textOverflow: 'ellipsis' }}
                   >
                     {elem.name}
                   </TableCell>
                   <TableCell
-                    sx={{ width: '25%', overflow: 'hidden', textOverflow: 'ellipsis' }}
+                    align="center"
+                    sx={{
+                      margin: '1px', padding: '0', width: '10%',
+                    }}
                   >
                     <Box
                       component="img"
                       sx={{
-                        height: 233,
-                        width: 250,
-                        maxHeight: { xs: 120, md: 167 },
-                        maxWidth: { xs: 140, md: 250 },
+                        margin: '3px auto',
+                        height: '60px',
+                        width: '60px',
+                        objectFit: 'cover',
+                        borderRadius: '50%',
                       }}
-                      src={elem.image}
+                      src={isImage(elem.image) || elem.image.length > 10 ? elem.image : 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTKH2cSl_mcI1heNKNhcs7Qpg0OVCh8AsiD5A&usqp=CAU'}
                       alt="news image"
                     />
                   </TableCell>
                   <TableCell
-                    sx={{ width: '25%', overflow: 'hidden', textOverflow: 'ellipsis' }}
+                    sx={{
+                      width: '45%', textOverflow: 'ellipsis',
+                    }}
+                  >
+                    {elem.content.length < 80 ? elem.content : `${elem.content.substring(0, 80)}...` }
+                  </TableCell>
+                  <TableCell
+                    sx={{ width: '15%', overflow: 'hidden', textOverflow: 'ellipsis' }}
                   >
                     {elem.createdAt}
 
                   </TableCell>
-                  <TableCell sx={{ padding: '0', width: '25%' }} align="center">
+                  <TableCell sx={{ padding: '0', width: '10 %' }} align="center">
                     <>
                       <Link to={`${elem.id}/edit`}>
                         <EditIcon sx={{

--- a/src/components/Contact/ContactScreen.jsx
+++ b/src/components/Contact/ContactScreen.jsx
@@ -9,9 +9,9 @@ import ContactFormContainer from '../Forms/ContactForm/ContactFormContainer'
 
 const ContactScreen = () => (
   <>
-    <Grid container>
+    <Grid container sx={{ maxWidth: '1600px', margin: 'auto' }}>
       <Grid item container justifyContent="center">
-        <Typography m="10px" variant="h5" fontWeight="bold">
+        <Typography margin="10px 5px 25px 15px" variant="h5" fontWeight="bold">
           ¡Contactate con nosotros!
         </Typography>
       </Grid>
@@ -36,8 +36,8 @@ const ContactScreen = () => (
           md={10}
           lg={10}
           xl={8}
-          display="flex"
           padding={{ xs: '2rem 0', md: '0 2rem' }}
+          display="flex"
           flexDirection="column"
         >
           <Typography variant="subtitle">

--- a/src/components/Forms/ContactForm/ContactForm.jsx
+++ b/src/components/Forms/ContactForm/ContactForm.jsx
@@ -18,10 +18,6 @@ const ContactForm = (props) => {
         <Box
           sx={{
             marginTop: 2,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'flex-start',
-            justifyContent: 'center',
           }}
         >
           <Formik
@@ -34,7 +30,7 @@ const ContactForm = (props) => {
               <Form>
                 <Grid container spacing={1}>
                   <Grid item xs={12}>
-                    <FormInputField label="Nombre" name="name" type="text" variant="outlined" autoFocus sx={{ h: 10 }} />
+                    <FormInputField label="Nombre" name="name" type="text" variant="outlined" sx={{ h: 10 }} />
                   </Grid>
                   <Grid item xs={12}>
                     <FormInputField label="Email" name="email" type="email" variant="outlined" />
@@ -42,25 +38,33 @@ const ContactForm = (props) => {
                   <Grid item xs={12}>
                     <FormInputField label="Escribe tu consulta..." name="message" variant="outlined" multiline rows={6} />
                   </Grid>
-                  <Grid item xs={4}>
+                  <Grid
+                    item
+                    xs={12}
+                    display="flex"
+                    justifyContent="start"
+                    gap="10px"
+                  >
                     <Button
                       type="submit"
                       variant="contained"
-                      color="secondary"
-                      sx={{
-                        mt: 1,
-                        mb: 1,
-                        h: 10,
-                        minWidth: 150,
-                      }}
+                      color="primary"
                     >
-                      Enviar Consulta
+                      Enviar
+                    </Button>
+                    <Button
+                      onClick={() => navigate('/')}
+                      variant="outlined"
+                    >
+                      Ir al inicio
                     </Button>
                   </Grid>
                   <Grid item>
                     {errorStatus && (
                     <Alert severity="error" sx={{ width: '100%' }} onClose={() => { setErrorStatus(null) }}>
                       No se ha podido enviar su consulta —
+                      {' '}
+                      {errorStatus}
                     </Alert>
                     )}
                   </Grid>
@@ -73,20 +77,9 @@ const ContactForm = (props) => {
                           setContactCreated(false)
                         }}
                       >
-                        Su consulta ha sido enviada! —
+                        Su consulta ha sido enviada!
                       </Alert>
                     ) : null}
-                  </Grid>
-                  <Grid item xs={12}>
-                    <Button
-                      onClick={() => navigate('/')}
-                      variant="outlined"
-                      sx={{
-                        mt: 1, mb: 1, h: 10, color: 'black', borderColor: 'black',
-                      }}
-                    >
-                      Ir al inicio
-                    </Button>
                   </Grid>
                 </Grid>
               </Form>


### PR DESCRIPTION
- Changed column width to better display content according to column content
- Added news content column and set a max content display on table
- Images added as well as a fallback image
-Added sticky header

## Evidence:
![image](https://user-images.githubusercontent.com/547180/195481539-7c2125ec-86b8-447b-9788-d6ef4fbafb8f.png)
