### PR TITLE
[FIX] OT287-F36: Fix typo in deleteModal usage

### DIFF
--- a/src/components/BackOffice/Activities/Activities.jsx
+++ b/src/components/BackOffice/Activities/Activities.jsx
@@ -15,7 +15,7 @@ const Activities = (
 
   const {
     activities, handleModal, setHandleModal, setElementToDelete, elementToDelete,
-    deleteElement, deletedSucces, errorStatus, errorStatusActivities, setDeletedSucces,
+    deleteElement, deletedSuccess, errorStatus, errorStatusActivities, setDeletedSuccess,
   } = props
 
   return (
@@ -115,10 +115,10 @@ const Activities = (
         setHandleModal={setHandleModal}
         elementToDelete={elementToDelete}
         deleteElement={deleteElement}
-        deletedSucces={deletedSucces}
+        deletedSuccess={deletedSuccess}
         errorStatus={errorStatus}
         setElementToDelete={setElementToDelete}
-        setDeletedSucces={setDeletedSucces}
+        setDeletedSuccess={setDeletedSuccess}
       />
       </>
  )

--- a/src/components/BackOffice/Activities/ActivitiesContainer.jsx
+++ b/src/components/BackOffice/Activities/ActivitiesContainer.jsx
@@ -9,7 +9,7 @@ const ActivitiesContainer = () => {
   const [handleModal, setHandleModal] = useState(false)
   const [elementToDelete, setElementToDelete] = useState({})
   const [errorStatus, setErrorStatus] = useState('')
-  const [deletedSucces, setDeletedSucces] = useState(false)
+  const [deletedSuccess, setDeletedSuccess] = useState(false)
   const [dataActivities, setDataActivities] = useState([])
   const [errorStatusActivities, setErrorStatusActivities] = useState('')
   const [loading, setLoading] = useState(false)
@@ -33,7 +33,7 @@ const ActivitiesContainer = () => {
     try {
       const data = await httpService('delete', `/activities/${id}`)
       if (data.code === 200) {
-        setDeletedSucces(true)
+        setDeletedSuccess(true)
         getActivitiesData()
       } else {
         setErrorStatus(data.code)
@@ -63,10 +63,10 @@ const ActivitiesContainer = () => {
         setElementToDelete={setElementToDelete}
         elementToDelete={elementToDelete}
         deleteElement={deleteElement}
-        deletedSucces={deletedSucces}
+        deletedSuccess={deletedSuccess}
         errorStatus={errorStatus}
         errorStatusActivities={errorStatusActivities}
-        setDeletedSucces={setDeletedSucces}
+        setDeletedSuccess={setDeletedSuccess}
       />
     </div>
   </>

--- a/src/components/BackOffice/Categories/CategoriesContainer.jsx
+++ b/src/components/BackOffice/Categories/CategoriesContainer.jsx
@@ -76,8 +76,8 @@ const CategoriesContainer = () => {
       setElementToDelete={setElementToDelete}
       elementToDelete={elementToDelete}
       deleteElement={deleteElement}
-      deletedSucces={deletedSuccess}
-      setDeletedSucces={setDeletedSuccess}
+      deletedSuccess={deletedSuccess}
+      setDeletedSuccess={setDeletedSuccess}
       errorStatus={errorStatus}
     />
   )

--- a/src/components/BackOffice/ItemCard.jsx
+++ b/src/components/BackOffice/ItemCard.jsx
@@ -14,7 +14,7 @@ import DeleteModal from '../Layout/DeleteModal'
 const ItemCard = (props) => {
   const {
     data, fields, nestedRoutes, handleModal, setHandleModal, setElementToDelete, elementToDelete,
-    deleteElement, deletedSucces, setDeletedSucces, errorStatus,
+    deleteElement, deletedSuccess, setDeletedSuccess, errorStatus,
   } = props
   const navigate = useNavigate()
 
@@ -64,10 +64,10 @@ const ItemCard = (props) => {
         setHandleModal={setHandleModal}
         elementToDelete={elementToDelete}
         deleteElement={deleteElement}
-        deletedSucces={deletedSucces}
+        deletedSuccess={deletedSuccess}
         errorStatus={errorStatus}
         setElementToDelete={setElementToDelete}
-        setDeletedSucces={setDeletedSucces}
+        setDeletedSuccess={setDeletedSuccess}
       />
     </Card>
   )
@@ -93,8 +93,8 @@ ItemCard.propTypes = {
   setElementToDelete: PropTypes.func.isRequired,
   elementToDelete: PropTypes.oneOfType([PropTypes.object]).isRequired,
   deleteElement: PropTypes.func.isRequired,
-  deletedSucces: PropTypes.bool.isRequired,
-  setDeletedSucces: PropTypes.func.isRequired,
+  deletedSuccess: PropTypes.bool.isRequired,
+  setDeletedSuccess: PropTypes.func.isRequired,
   errorStatus: PropTypes.string.isRequired,
 }
 

--- a/src/components/BackOffice/Testimonials/Testimonials.jsx
+++ b/src/components/BackOffice/Testimonials/Testimonials.jsx
@@ -14,8 +14,8 @@ const Testimonials = (
 ) => {
   const {
     testimonials, handleModal, setHandleModal, setElementToDelete, elementToDelete,
-    deleteElement, deletedSucces, errorStatus, getTestimonialsData, errorStatusTestimonials,
-    setDeletedSucces,
+    deleteElement, deletedSuccess, errorStatus, getTestimonialsData, errorStatusTestimonials,
+    setDeletedSuccess,
   } = props
   const navigate = useNavigate()
   return (
@@ -109,11 +109,11 @@ const Testimonials = (
         setHandleModal={setHandleModal}
         elementToDelete={elementToDelete}
         deleteElement={deleteElement}
-        deletedSucces={deletedSucces}
+        deletedSuccess={deletedSuccess}
         errorStatus={errorStatus}
         getTestimonialsData={getTestimonialsData}
         setElementToDelete={setElementToDelete}
-        setDeletedSucces={setDeletedSucces}
+        setDeletedSuccess={setDeletedSuccess}
       />
     </>
   )
@@ -130,10 +130,10 @@ Testimonials.propTypes = {
   setElementToDelete: PropTypes.func.isRequired,
   elementToDelete: PropTypes.oneOfType([PropTypes.object]).isRequired,
   deleteElement: PropTypes.func.isRequired,
-  deletedSucces: PropTypes.bool.isRequired,
+  deletedSuccess: PropTypes.bool.isRequired,
   errorStatus: PropTypes.string.isRequired,
   getTestimonialsData: PropTypes.func.isRequired,
   errorStatusTestimonials: PropTypes.string.isRequired,
-  setDeletedSucces: PropTypes.func.isRequired,
+  setDeletedSuccess: PropTypes.func.isRequired,
 }
 export default Testimonials

--- a/src/components/BackOffice/Testimonials/Testimonials.jsx
+++ b/src/components/BackOffice/Testimonials/Testimonials.jsx
@@ -7,15 +7,15 @@ import {
 import HighlightOffIcon from '@mui/icons-material/HighlightOff'
 import EditIcon from '@mui/icons-material/Edit'
 import { useNavigate } from 'react-router-dom'
-import TestimonialDeleteModal from '../../Layout/DeleteModal'
+import DeleteModal from '../../Layout/DeleteModal'
 
 const Testimonials = (
   props,
 ) => {
   const {
     testimonials, handleModal, setHandleModal, setElementToDelete, elementToDelete,
-    deleteElement, deletedSuccess, errorStatus, getTestimonialsData, errorStatusTestimonials,
-    setDeletedSuccess,
+    deleteElement, deletedSucces, errorStatus, getTestimonialsData, errorStatusTestimonials,
+    setDeletedSucces,
   } = props
   const navigate = useNavigate()
   return (
@@ -104,16 +104,16 @@ const Testimonials = (
           </Table>
         </TableContainer>
       </Box>
-      <TestimonialDeleteModal
+      <DeleteModal
         openModal={handleModal}
         setHandleModal={setHandleModal}
         elementToDelete={elementToDelete}
         deleteElement={deleteElement}
-        deletedSuccess={deletedSuccess}
+        deletedSucces={deletedSucces}
         errorStatus={errorStatus}
         getTestimonialsData={getTestimonialsData}
         setElementToDelete={setElementToDelete}
-        setDeletedSuccess={setDeletedSuccess}
+        setDeletedSucces={setDeletedSucces}
       />
     </>
   )
@@ -130,10 +130,10 @@ Testimonials.propTypes = {
   setElementToDelete: PropTypes.func.isRequired,
   elementToDelete: PropTypes.oneOfType([PropTypes.object]).isRequired,
   deleteElement: PropTypes.func.isRequired,
-  deletedSuccess: PropTypes.bool.isRequired,
+  deletedSucces: PropTypes.bool.isRequired,
   errorStatus: PropTypes.string.isRequired,
   getTestimonialsData: PropTypes.func.isRequired,
   errorStatusTestimonials: PropTypes.string.isRequired,
-  setDeletedSuccess: PropTypes.func.isRequired,
+  setDeletedSucces: PropTypes.func.isRequired,
 }
 export default Testimonials

--- a/src/components/BackOffice/Testimonials/TestimonialsContainer.jsx
+++ b/src/components/BackOffice/Testimonials/TestimonialsContainer.jsx
@@ -9,7 +9,7 @@ const TestimonialsContainer = () => {
   const [dataTestimonials, setDataTestimonials] = useState([])
   const [errorStatusTestimonials, setErrorStatusTestimonials] = useState('')
   const [elementToDelete, setElementToDelete] = useState({})
-  const [deletedSuccess, setDeletedSuccess] = useState(false)
+  const [deletedSucces, setDeletedSucces] = useState(false)
   const [errorStatus, setErrorStatus] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -33,7 +33,7 @@ const TestimonialsContainer = () => {
     try {
       const data = await httpService('delete', `/testimonials/${id}`)
       if (data.code === 200) {
-        setDeletedSuccess(true)
+        setDeletedSucces(true)
         getTestimonialsData()
       } else {
         setErrorStatus(data.code)
@@ -68,8 +68,8 @@ const TestimonialsContainer = () => {
       deleteElement={deleteElement}
       setElementToDelete={setElementToDelete}
       elementToDelete={elementToDelete}
-      deletedSuccess={deletedSuccess}
-      setDeletedSucces={setDeletedSuccess}
+      deletedSucces={deletedSucces}
+      setDeletedSucces={setDeletedSucces}
     />
   )
 }

--- a/src/components/BackOffice/Testimonials/TestimonialsContainer.jsx
+++ b/src/components/BackOffice/Testimonials/TestimonialsContainer.jsx
@@ -9,7 +9,7 @@ const TestimonialsContainer = () => {
   const [dataTestimonials, setDataTestimonials] = useState([])
   const [errorStatusTestimonials, setErrorStatusTestimonials] = useState('')
   const [elementToDelete, setElementToDelete] = useState({})
-  const [deletedSucces, setDeletedSucces] = useState(false)
+  const [deletedSuccess, setDeletedSuccess] = useState(false)
   const [errorStatus, setErrorStatus] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -33,7 +33,7 @@ const TestimonialsContainer = () => {
     try {
       const data = await httpService('delete', `/testimonials/${id}`)
       if (data.code === 200) {
-        setDeletedSucces(true)
+        setDeletedSuccess(true)
         getTestimonialsData()
       } else {
         setErrorStatus(data.code)
@@ -68,8 +68,8 @@ const TestimonialsContainer = () => {
       deleteElement={deleteElement}
       setElementToDelete={setElementToDelete}
       elementToDelete={elementToDelete}
-      deletedSucces={deletedSucces}
-      setDeletedSucces={setDeletedSucces}
+      deletedSuccess={deletedSuccess}
+      setDeletedSuccess={setDeletedSuccess}
     />
   )
 }

--- a/src/components/BackOffice/news/News.jsx
+++ b/src/components/BackOffice/news/News.jsx
@@ -14,8 +14,8 @@ const News = (
 ) => {
   const {
     news, handleModal, setHandleModal, setElementToDelete, elementToDelete,
-    deleteElement, deletedSucces, errorStatus, getNewsData, errorStatusNews,
-    setDeletedSucces,
+    deleteElement, deletedSuccess, errorStatus, getNewsData, errorStatusNews,
+    setDeletedSuccess,
   } = props
   return (
     <>
@@ -127,11 +127,11 @@ const News = (
         setHandleModal={setHandleModal}
         elementToDelete={elementToDelete}
         deleteElement={deleteElement}
-        deletedSucces={deletedSucces}
+        deletedSuccess={deletedSuccess}
         errorStatus={errorStatus}
         getNewsData={getNewsData}
         setElementToDelete={setElementToDelete}
-        setDeletedSucces={setDeletedSucces}
+        setDeletedSuccess={setDeletedSuccess}
       />
     </>
   )
@@ -149,10 +149,10 @@ News.propTypes = {
   setElementToDelete: PropTypes.func.isRequired,
   elementToDelete: PropTypes.oneOfType([PropTypes.object]).isRequired,
   deleteElement: PropTypes.func.isRequired,
-  deletedSucces: PropTypes.bool.isRequired,
+  deletedSuccess: PropTypes.bool.isRequired,
   errorStatus: PropTypes.string.isRequired,
   getNewsData: PropTypes.func.isRequired,
   errorStatusNews: PropTypes.string.isRequired,
-  setDeletedSucces: PropTypes.func.isRequired,
+  setDeletedSuccess: PropTypes.func.isRequired,
 }
 export default News

--- a/src/components/BackOffice/news/NewsContainer.jsx
+++ b/src/components/BackOffice/news/NewsContainer.jsx
@@ -8,7 +8,7 @@ const NewsContainer = () => {
   const [handleModal, setHandleModal] = useState(false)
   const [elementToDelete, setElementToDelete] = useState({})
   const [errorStatus, setErrorStatus] = useState('')
-  const [deletedSucces, setDeletedSucces] = useState(false)
+  const [deletedSuccess, setDeletedSuccess] = useState(false)
   const [dataNews, setDataNews] = useState([])
   const [errorStatusNews, setErrorStatusNews] = useState('')
   const [loading, setLoading] = useState(false)
@@ -32,7 +32,7 @@ const NewsContainer = () => {
     try {
       const data = await httpService('delete', `/news/${id}`)
       if (data.code === 200) {
-        setDeletedSucces(true)
+        setDeletedSuccess(true)
         getNewsData()
       } else {
         setErrorStatus(data.code)
@@ -61,11 +61,11 @@ const NewsContainer = () => {
         setElementToDelete={setElementToDelete}
         elementToDelete={elementToDelete}
         deleteElement={deleteElement}
-        deletedSucces={deletedSucces}
+        deletedSuccess={deletedSuccess}
         errorStatus={errorStatus}
         getNewsData={getNewsData}
         errorStatusNews={errorStatusNews}
-        setDeletedSucces={setDeletedSucces}
+        setDeletedSuccess={setDeletedSuccess}
       />
     </div>
   )

--- a/src/components/BackOffice/users/Users.jsx
+++ b/src/components/BackOffice/users/Users.jsx
@@ -13,8 +13,8 @@ const Users = (
   props,
   ) => { 
     const {users, handleModal, setHandleModal, setElementToDelete, elementToDelete,
-    deleteElement, deletedSucces, errorStatus, errorStatusUsers,
-    setDeletedSucces,
+    deleteElement, deletedSuccess, errorStatus, errorStatusUsers,
+    setDeletedSuccess,
   } = props 
    
   return (
@@ -116,10 +116,10 @@ const Users = (
        setHandleModal={setHandleModal}
        elementToDelete={elementToDelete}
        deleteElement={deleteElement}
-       deletedSucces={deletedSucces}
+       deletedSuccess={deletedSuccess}
        errorStatus={errorStatus}
        setElementToDelete={setElementToDelete}
-       setDeletedSucces={setDeletedSucces}
+       setDeletedSuccess={setDeletedSuccess}
      />
      </>
   )

--- a/src/components/BackOffice/users/UsersContainer.jsx
+++ b/src/components/BackOffice/users/UsersContainer.jsx
@@ -11,7 +11,7 @@ const UsersContainer = () => {
   const [errorStatusUsers, setErrorStatusUsers] = useState('')
   const [handleModal, setHandleModal] = useState(false)
   const [elementToDelete, setElementToDelete] = useState({})
-  const [deletedSucces, setDeletedSucces] = useState(false)
+  const [deletedSuccess, setDeletedSuccess] = useState(false)
 
   const getUsersData = useCallback(async () => {
     setLoading(true)
@@ -33,7 +33,7 @@ const UsersContainer = () => {
     try {
       const data = await httpService('delete', `/users/${id}`)
       if (data.code === 200) {
-        setDeletedSucces(true)
+        setDeletedSuccess(true)
         getUsersData()
       } else {
         setErrorStatus(data.code)
@@ -62,10 +62,10 @@ const UsersContainer = () => {
   setElementToDelete={setElementToDelete}
   elementToDelete={elementToDelete}
   deleteElement={deleteElement}
-  deletedSucces={deletedSucces}
+  deletedSuccess={deletedSuccess}
   errorStatus={errorStatus}
   errorStatusUsers={errorStatusUsers}
-  setDeletedSucces={setDeletedSucces}
+  setDeletedSuccess={setDeletedSuccess}
   />
 }
 

--- a/src/components/Layout/DeleteModal.jsx
+++ b/src/components/Layout/DeleteModal.jsx
@@ -8,13 +8,13 @@ import {
 const DeleteModal = (props) => {
   const {
     openModal, setHandleModal, elementToDelete, deleteElement,
-    deletedSucces, errorStatus, setElementToDelete, setDeletedSucces,
+    deletedSuccess, errorStatus, setElementToDelete, setDeletedSuccess,
   } = props
   return (
     <>
       <Dialog open={openModal}>
 
-        { deletedSucces === false ? (
+        { deletedSuccess === false ? (
           <>
             <DialogTitle>
               Estas seguro de eliminar
@@ -41,14 +41,14 @@ const DeleteModal = (props) => {
 
         ) : null }
 
-        {deletedSucces ? (
+        {deletedSuccess ? (
 
           <Alert
-            severity="success"
+            severity="Successs"
             onClose={() => {
               setHandleModal(false)
               setElementToDelete(null)
-              setDeletedSucces(false)
+              setDeletedSuccess(false)
             }}
           >
             {elementToDelete ? elementToDelete.name : null}
@@ -79,10 +79,10 @@ DeleteModal.propTypes = {
   setHandleModal: PropTypes.func.isRequired,
   elementToDelete: PropTypes.oneOfType([PropTypes.object]).isRequired,
   deleteElement: PropTypes.func.isRequired,
-  deletedSucces: PropTypes.bool.isRequired,
+  deletedSuccess: PropTypes.bool.isRequired,
   errorStatus: PropTypes.string.isRequired,
   setElementToDelete: PropTypes.func.isRequired,
-  setDeletedSucces: PropTypes.func.isRequired,
+  setDeletedSuccess: PropTypes.func.isRequired,
 
 }
 


### PR DESCRIPTION
We were using "Succes" instead of "Success". Fixed that in all backoffice menus


