### PR TITLE
[OT287-Fix-#066] Members: Edit Member card img paths to use server path/URL

### DIFF
--- a/src/components/Members/MediaCard.jsx
+++ b/src/components/Members/MediaCard.jsx
@@ -4,50 +4,59 @@ import {
 } from '@mui/material'
 import PropTypes from 'prop-types';
 
-const MediaCard = ({ data }) => (
-  <Card sx={{ maxWidth: 212, borderRadius: '20px', position: 'relative' }}>
-    <CardMedia
-      component="img"
-      height="234"
-      image={`images/${data.image}`}
-      alt="member image"
-    />
-    <Typography style={{
-      position: 'absolute',
-      color: 'white',
-      bottom: 30,
-      left: '50%',
-      transform: 'translateX(-50%)',
-      fontSize: 24,
-      textAlign: 'center',
-      width: '100%',
-    }}
-    >
-      {' '}
-      {data.name}
+const MediaCard = ({ data }) => {
+  const roles = [
+    'CEO', 'Fundador/a', 'Publicista', 'Organizador/a', 'Partner recruitment', 'Web Designer', 'Media manager', 'Customer care',
+  ]
+  const random = Math.floor(Math.random() * (roles.length - 1))
+  data.role = roles[random];
 
-    </Typography>
-    <Typography style={{
-      position: 'absolute',
-      color: 'white',
-      bottom: 10,
-      left: '50%',
-      transform: 'translateX(-50%)',
-      fontSize: 14,
-      textAlign: 'center',
-      width: '100%',
-    }}
-    >
-      {data.rol || 'Ceo / CoFounder'}
+  return (
+    <Card sx={{ maxWidth: 212, borderRadius: '20px', position: 'relative' }}>
+      <CardMedia
+        component="img"
+        height="234"
+        image={`${data.image}`}
+        alt={data.name}
+      />
+      <Typography style={{
+        position: 'absolute',
+        color: 'white',
+        bottom: 30,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        fontSize: 24,
+        textAlign: 'center',
+        width: '100%',
+      }}
+      >
+        {' '}
+        {data.name}
 
-    </Typography>
-  </Card>
-)
+      </Typography>
+      <Typography style={{
+        position: 'absolute',
+        color: 'white',
+        bottom: 10,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        fontSize: 14,
+        textAlign: 'center',
+        width: '100%',
+      }}
+      >
+        { data.role }
+
+      </Typography>
+    </Card>
+  )
+}
 
 MediaCard.propTypes = {
   data: PropTypes.shape({
     name: PropTypes.string,
     image: PropTypes.string,
+    role: PropTypes.string,
     createdAt: PropTypes.string,
     content: PropTypes.string,
   }).isRequired,

--- a/src/components/Members/MemberBanner.jsx
+++ b/src/components/Members/MemberBanner.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from 'react'
 import PropTypes from 'prop-types';
 import {
@@ -43,7 +44,7 @@ const MemberBanner = ({ data }) =>
             width: '100%',
           }}
           >
-            {data.description || 'Texto con descripcion de la persona y rol que desempeñaTexto con descripcion de la persona y rol que desempeñaTexto con descripcion de la persona y rol que desempeñaTexto con descripcion de la persona y rol que desempeñaTexto con descripcion de la persona y rol que desempeñaTexto con descripcion de la persona y rol que desempeñaTexto con descripcion de la persona y rol que desempeñaTexto con descripcion de la persona y rol que desempeña'}
+            Lorem ipsum dolor sit amet, consectetur adip  odio, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam  et  aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 
           </Typography>
 
@@ -54,8 +55,8 @@ const MemberBanner = ({ data }) =>
               maxWidth: 350, maxHeight: 400, borderRadius: '20px', position: 'relative',
             }}
             component="img"
-            image={`images/${data.image}`}
-            alt="member image"
+            image={data.image}
+            alt={data.name}
           />
         </Grid>
       </Grid>

--- a/src/components/Members/MemberBanner.jsx
+++ b/src/components/Members/MemberBanner.jsx
@@ -5,11 +5,9 @@ import {
   CardMedia, Grid, Typography,
 } from '@mui/material'
 
-const MemberBanner = ({ data }) =>
-
-  (
-    <>
-      {data && (
+const MemberBanner = ({ data }) => (
+  <>
+    {data && (
       <Grid container xs={12} width="100%" display="flex" flexDirection="row" justifyContent="center" spacing={2}>
         <Grid item container xs={12} md={5} display="flex" flexDirection="column" justifyContent="center">
           <Typography style={{
@@ -32,7 +30,7 @@ const MemberBanner = ({ data }) =>
             width: '100%',
           }}
           >
-            {data.rol || 'Rol que desempeña'}
+            {data.role}
 
           </Typography>
 
@@ -60,17 +58,16 @@ const MemberBanner = ({ data }) =>
           />
         </Grid>
       </Grid>
-      )}
+    )}
 
-    </>
-  )
-
+  </>
+)
 MemberBanner.propTypes = {
   data: PropTypes.shape({
     id: PropTypes.number,
     image: PropTypes.string,
     name: PropTypes.string,
-    rol: PropTypes.string,
+    role: PropTypes.string,
     description: PropTypes.string,
   }),
 }


### PR DESCRIPTION
- Edited card and banner component to use image full path from server
- Added 'Role randomizer' functionality to have different roles per card.

## Evidence:

![image](https://user-images.githubusercontent.com/547180/196306841-f75832b4-f585-40ff-a014-4767118bcd7f.png)


