### PR TITLE
[OT287-Fix-#077] News by ID: changes in news by id layout to fix max container length

### DIFF
--- a/src/components/News/NewById.jsx
+++ b/src/components/News/NewById.jsx
@@ -7,10 +7,12 @@ import './newById.css'
 
 const NewById = ({ data }) => (
 
-  <Grid item xs={12} height="100vh" width="100%">
+  <Grid item xs={12} height="100%" width="100%" maxWidth="1600px">
     <Paper
       sx={{
-        height: '60%',
+        height: '30vw',
+        minHeight: '240px',
+        minWidth: '250px',
         position: 'relative',
         backgroundSize: 'cover',
         backgroundRepeat: 'no-repeat',
@@ -34,17 +36,20 @@ const NewById = ({ data }) => (
       <Grid item md={12}>
         <Box
           sx={{
-            position: 'relative',
-            p: { xs: 1, md: 2 },
-            pr: { md: 0 },
+            margin: '30px 0 10px 0',
+            minWidth: '250px',
           }}
         >
-          <Typography className="newByIdTitle" variant="h3" color="inherit" gutterBottom>
+          <Typography
+            className="newByIdTitle"
+            color="inherit"
+            sx={{ typography: { lg: 'h4', xs: 'h5' }, margin: '10px 0' }}
+          >
             {data.name}
           </Typography>
           <Typography
             className="newByIdParagraph"
-            variant="h6"
+            sx={{ typography: { lg: 'h6', xs: 'p' } }}
             color="inherit"
             paragraph
             dangerouslySetInnerHTML={{ __html: data.content }}

--- a/src/components/News/NewByIdContainer.jsx
+++ b/src/components/News/NewByIdContainer.jsx
@@ -12,7 +12,7 @@ const NewByIdContainer = () => {
       .then((response) => { setData(response.body) })
   }, [id])
   return (
-    <Box sx={{ m: '60px 50px 10px 50px' }}>
+    <Box sx={{ m: { lg: '60px 50px 10px 50px', xs: '30px 25px 5px 25px' } }}>
       <NewById data={data} />
     </Box>
   )


### PR DESCRIPTION
- Text was spilling out outside boundaries in the footer, text dize did not match layout, etc.

BEFORE
![image](https://user-images.githubusercontent.com/547180/196826465-06b10df9-4041-429d-a2b1-b54997aa73bb.png)

![2022-10-19_21-00-30](https://user-images.githubusercontent.com/547180/196826482-01f15685-3d5d-4bca-be8e-3eeb4e18c0ec.gif)


AFTER
![image](https://user-images.githubusercontent.com/547180/196826332-4f7aa02f-981f-46fd-a004-5145b04a10de.png)

![2022-10-19_20-59-35](https://user-images.githubusercontent.com/547180/196826383-7e28de9a-bfd6-4561-a68a-f1140ad643b5.gif)

