### PR TITLE
[OT287-Fix-#078] Slider: edited text size and location for text on mobile and desktop view

### DIFF
--- a/src/components/Slider/Slider.jsx
+++ b/src/components/Slider/Slider.jsx
@@ -40,7 +40,7 @@ const Slider = ({ items }) => (
     {items
       && items.map((item) => (
         <Box key={item.id} sx={{ maxHeight: '31.25rem', marginTop: '2rem' }}>
-          <Box component="img" src={item.imageUrl} alt={item.text} sx={{ width: '100%', height: { xs: '250px', md: '500px' }, objectFit: 'cover' }} />
+          <Box component="img" src={item.imageUrl} alt={item.text} sx={{ width: '100%', height: { xs: '250px', md: '500px' }, objectFit: 'cover'}} />
           <Box
             sx={{
               position: 'absolute',
@@ -53,13 +53,13 @@ const Slider = ({ items }) => (
           />
           {item.text ? (
             <Typography
-              fontSize={{ xs: '.5rem', md: '.8rem', lg: '1.3rem' }}
+              fontSize={{ xs: '.75rem', lg: '1.2rem' }}
               style={{
                 position: 'absolute',
                 color: 'white',
-                bottom: 120,
-                left: '47%',
-                transform: 'translateX(-50%)',
+                top: '40%',
+                left: '50%',
+                transform: 'translate(-50%,-40%)',
                 textAlign: 'left',
                 width: '80%',
               }}


### PR DESCRIPTION
BEFORE
![image](https://user-images.githubusercontent.com/547180/196833722-e8e4a9cd-1f96-4fb6-8c1c-6c4f4b6aa4ee.png)
![image](https://user-images.githubusercontent.com/547180/196833687-5278f26e-8c6b-4b76-9312-e7b5602417f3.png)



AFTER
![image](https://user-images.githubusercontent.com/547180/196833536-50277928-98a5-44c2-ab7e-91bd3e258be1.png)
![image](https://user-images.githubusercontent.com/547180/196833578-5e5dccca-17bd-4ebe-9a98-50e533efb605.png)



