### PR TITLE
[OT287-Fix-#080]News Form: hide category disabled field for type of entr, as we're only displayi…

### DIFF
--- a/src/components/Forms/NewsForm/NewsForm.jsx
+++ b/src/components/Forms/NewsForm/NewsForm.jsx
@@ -70,7 +70,7 @@ const NewsForm = ({
                     />
                     <ErrorMessage name="signator_text" />
                   </Grid>
-                  <Grid item xs={12}>
+                  <Grid item xs={12} display="none">
                     <FormInputField label="Categoría" name="categoryId" variant="outlined" disabled />
                   </Grid>
                   <Grid item xs={12}>


### PR DESCRIPTION
-Hid the CategoryId field which is hardcoded and disabled. Still works the same

## Evidence:
Before
![image](https://user-images.githubusercontent.com/547180/196969620-22c2cff7-23e5-4475-9b9d-d817b8d6ceec.png)

After
![image](https://user-images.githubusercontent.com/547180/196969508-0ce78806-8cb0-443e-bb49-344ec487a535.png)


