### PR TITLE
[FIX] Replace spaces in images names

### DIFF
--- a/src/components/Forms/NewsForm/NewsForm.jsx
+++ b/src/components/Forms/NewsForm/NewsForm.jsx
@@ -57,7 +57,7 @@ const NewsForm = ({
                     <FormInputField label="Título" name="name" type="text" variant="outlined" autoFocus sx={{ h: 10 }} />
                   </Grid>
                   <Grid item xs={12}>
-                    <FormInputField label="Imagen actual:" name="uploadedImage" type="text" variant="standard" />
+                    <FormInputField label="Imagen actual:" name="uploadedImage" type="text" variant="standard" disabled />
                     <FormInputImage label="Upload" id="image" name="image" formProps={formProps} marginTop="10px" />
                   </Grid>
                   <Grid item xs={12}>

--- a/src/components/Layout/AWSFileUpload.js
+++ b/src/components/Layout/AWSFileUpload.js
@@ -11,8 +11,9 @@ const AWSFileUpload = async (file, folder) => {
   }
 
   const getName = (async () => {
+    const name = file.name.replace(' ', '_')
     const date = new Date()
-    const fullName = `${date.getFullYear()}${date.getMonth() + 1}${date.getDate()}${date.getHours()}${date.getMinutes()}${date.getSeconds()}_${file.name}`
+    const fullName = `${date.getFullYear()}${date.getMonth() + 1}${date.getDate()}${date.getHours()}${date.getMinutes()}${date.getSeconds()}_${name}`
     return fullName
   })
 


### PR DESCRIPTION
...and readded the "disable" property to the "imagen actual" field while editing news.


![image](https://user-images.githubusercontent.com/79290983/197349924-203a64b3-1e2d-4005-a8e8-a351ceb17941.png)

![image](https://user-images.githubusercontent.com/79290983/197349956-9f8720f8-f581-4106-a0b8-3baf88195d53.png)

![image](https://user-images.githubusercontent.com/79290983/197350088-688953d1-a64f-49de-8a44-90fe4f0db5d1.png)


